### PR TITLE
Arcus v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 < BEING REWRITTEN >
 
-Arcus is a simple lightweight Scriptable Package Manager.
+Arcus is a simple lightweight Scriptable Package Manager compliant with `-std=c99` whilst implementing OS-Specific implementations where required.
 
-It is written in C and is meant to be easily configurable, internally of course. Support for external files will come soon.
-- If you wish to add more environment variables then you may do so in the `env_args` 2D Array.
-- If you wish to add more packages to the script then you may do so in the `packages` 2D Array.
+It is written in C and is meant to be easily configurable using `arcus.pkgs` and `arcus.envs`. The syntax for such files is quite `strict` so please follow it accordingly.
+- If you wish to add more packages to the script then you may do so in the `arcus_config/arcus.pkgs` 2D Array.
+- If you wish to add more environment variables then you may do so in `arcus_config/arcus.envs`
+
+> [!WARNING]
+> Ensure you put a comma at the previous-most `}` to separate packages and/or environment variables in `arcus.pkgs` and `arcus.envs` otherwise they **WON'T** be parsed.
 
 > [!IMPORTANT]
-> Read [Usage](#usage) if you wish to learn how to use arcus.
+> Read [Usage](#usage) if you wish to learn how to use `Arcus`.
 > 
 > Read [Format](#format) if you wish to implement new environment variables and packages.
+>
+> Read [Credits](#credits) for a list of Credits.
 
 ## Usage
 > [!NOTE]
@@ -24,60 +29,53 @@ It is written in C and is meant to be easily configurable, internally of course.
 ```bash
 usage: arcus <operation> [...]
 operations:
-	arcus {-h --help}
-	arcus {-V --version}
-	arcus list {--ignore ...} (arguments after --ignore are listed as ignored packages, separated by a whitespace)
-	arcus install {--ignore ...} (may require root permissions, arguments after --ignore are listed as ignored packages, separated by a whitespace)
+				arcus {-h --help}
+				arcus {-V --version}
+				arcus list {--ignore ...} (arguments after --ignore are listed as ignored packages, separated by a whitespace)
+				arcus install {--ignore ...} (may require root permissions, arguments after --ignore are listed as ignored packages, separated by a whitespace)
 ```
 
 ## Format
 
 > static const char* env_args[][2] {...}
-```c
-// DEFAULT env_args IMPLEMENTATION
-static const char* env_args[][2] = {
-  {
-    "ARCUS_SU_PACMAN",
-    "sudo pacman -S"
-  },
-  {
-    "ARCUS_DEFAULT_PACMAN_ARGS",
-    "--needed --noconfirm"
-  },
-  {
-    "ARCUS_YAY",
-    "yay -S"
-  },
-  {
-    "ARCUS_DEFAULT_YAY_ARGS",
-    "--needed --noconfirm"
-  }
-};
+```
+{
+	"ARCUS_SU_PACMAN",
+	"sudo pacman -S"
+},
+{
+	"ARCUS_DEFAULT_PACMAN_ARGS",
+	"--needed --noconfirm"
+},
+{
+	"ARCUS_YAY",
+	"yay -S"
+},
+{
+	"ARCUS_DEFAULT_YAY_ARGS",
+	"--needed --noconfirm"
+}
 ```
 > [!WARNING]
-> Implementing an environment variable in `env_args` WILL call `int setenv(const char *name, const char *value, int overwrite)` with the `int overwrite` flag set to `1` `(true)`. Hence, be cautious about overwriting already-existing environment variables in your Shell Session. Though they will reset upon exiting the Shell Session.
+> Implementing an environment variable in `arcus_config/arcus.envs` WILL call `int setenv(const char *name, const char *value, int overwrite)` internally with the `int overwrite` flag set to `1` `(true)`. Hence, be cautious about overwriting already-existing environment variables in your Shell Session. Though they will reset upon exiting the Shell Session.
 
-For example if you wanted to add the environment variable for compiling something with `clang`, you can implement it as so:
-```c
-static const char* env_args[][2] = {
-  ...
-  {
-    "ARCUS_CLANG",
-    "clang -Wall -Wextra -pedantic -o"
-  }
-  ...
-};
+For example if you wanted to add the environment variable for compiling something with `clang`, you can implement it as so in `arcus_config/arcus.envs`:
 ```
-This environment variable can then be implemented in a `package` as so:
-```c
-static const char* packages[][2] = {
-  ...
-  {
-    "arcus",
-    "${ARCUS_CLANG} ${ARCUS_PACKAGES} ${ARCUS_PACKAGES}.c"
-  }
-  ...
-};
+...
+{
+	"ARCUS_CLANG",
+	"clang -Wall -Wextra -pedantic -o"
+}
+...
+```
+This environment variable can then be implemented in `arcus_config/arcus.pkgs` as so:
+```
+...
+{
+	"arcus",
+	"${ARCUS_CLANG} ${ARCUS_PACKAGES} ${ARCUS_PACKAGES}.c"
+}
+...
 ```
 
 Where the environment variables expand to the following:
@@ -85,33 +83,28 @@ Where the environment variables expand to the following:
 - `${ARCUS_PACKAGES}` expands to `arcus` (the header of your package)
 
 > static const char* packages[][2] {...}
-
-```c
-static const char* packages[][2] = {
-  {
-    "package-header",
-    "commands-to-run-to-install-package-header"
-  },
-  {
-    "package-header-2",
-    "commands-to-run-to-install-package-header-2
-  }
-};
+```
+{
+	"package-header",
+	"commands-to-run-to-install-package-header"
+},
+{
+	"package-header-2",
+	"commands-to-run-to-install-package-header-2
+}
 ```
 
 > [!CAUTION]
 > Do ***NOT*** implement a package header that contains a whitespace if you wish for it to be ignorable using the `--ignore ...` flag. Otherwise, if you wish to install multiple packages at once using `${ARCUS_PACKAGES}` then you may put multiple headers such you require it.
 
 For example, if you wanted to install `neofetch` with `sudo pacman -S` you can implement a package as so:
-```c
-static const char* packages[][2] {
-  ...
-  {
-    "neofetch",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}
-  }
-  ...
-};
+```
+...
+{
+	"neofetch",
+	"${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}
+}
+...
 ```
 Where the environment variables expand to the following:
 - `${ARCUS_SU_PACMAN}` expands to `sudo pacman -S`
@@ -119,3 +112,29 @@ Where the environment variables expand to the following:
 - `${ARCUS_PACKAGES}` expands to `neofetch` (the header of your package)
 
 Refer to [env_args](#format) in regards to environment variables as such as `${ARCUS_SU_PACMAN}`, `${ARCUS_DEFAULT_PACMAN_ARGS}` and `${ARCUS_PACKAGES}` 
+
+> [!TIP]
+> If you wish to run multiple commands at once for each package, then refer to your Operating Systems guide on how to separate commands in your `Default Terminal` as `Arcus` takes use of `int system(const char* command)`.
+> For example in `bash`, commands can be separated by trailing semi-colons (`;`).
+> 
+> In Windows, if your Shell is PowerShell the same is apparent.
+>
+> An example of this, in `bash` would be the following:
+```
+...
+{
+	"lolcat",
+	"${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}; echo \"Hello, World!\" | lolcat"`
+}
+...
+```
+> [!WARNING]
+> Ensure all of your commands are within a single string and not on a newline as the parser won't pick this up and may potentially cause further issues for Arcus Script.
+
+# Credits
+
+> Authored and programmed by [SigmaEG](https://github.com/SigmaEG)
+>
+> Last Updated: 14th January, 2024
+>
+> Script Manager

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Arcus v0.2.9
+# Arcus v1.1.2
+
+< BEING REWRITTEN >
 
 Arcus is a simple lightweight Scriptable Package Manager.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Refer to [env_args](#format) in regards to environment variables as such as `${A
 ...
 {
 	"lolcat",
-	"${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}; echo \"Hello, World!\" | lolcat"`
+	"${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}; echo \"Hello, World!\" | lolcat"
 }
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Arcus v1.1.2
 
-< BEING REWRITTEN >
-
 Arcus is a simple lightweight Scriptable Package Manager compliant with `-std=c99` whilst implementing OS-Specific implementations where required.
 
 It is written in C and is meant to be easily configurable using `arcus.pkgs` and `arcus.envs`. The syntax for such files is quite `strict` so please follow it accordingly.

--- a/arcus.c
+++ b/arcus.c
@@ -1,7 +1,7 @@
 /**
  * @name Arcus
  * @author https://github.com/SigmaEG/Arcus
- * @note Last Updated: 13th January, 2024
+ * @note Last Updated: 14th January, 2024
  * @note Script Manager
  */
 
@@ -347,7 +347,7 @@
 
   #pragma region OS-SPECIFIC DECLARATIONS
 
-    #ifdef __unix__
+    #if defined(__unix__) || defined(__linux__)
       bool
       has_neofetch(void) {
         if (pathexists("/usr/local/bin/neofetch")
@@ -374,7 +374,7 @@
       }
     #endif
 
-    #ifdef _WIN32
+    #if defined(_WIN32)
       // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
       #ifdef ARCUS_INITED_WIN_TERM_PROC
         static HANDLE stdout_handle;
@@ -516,7 +516,7 @@
     const char* name,
     const char* value
   ) {
-    #ifdef __unix__
+    #if defined(__unix__) || defined(__linux__)
       if (has_lolcat()) {
         char* lolcat = (char*)calloc(strlen("echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
         sprintf(lolcat, "echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
@@ -535,7 +535,7 @@
       return false;
     }
     
-    #ifdef __unix__
+    #if defined(__unix__) || defined(__linux__)
       if (has_lolcat()) {
         char* lolcat = (char*)calloc(strlen("echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
         sprintf(lolcat, "echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
@@ -843,7 +843,7 @@ int32_t main(
   int32_t argc,
   const char** argv
 ) {
-  #ifdef _WIN32
+  #if defined(_WIN32)
     enable_ansi();
   #endif
 
@@ -856,7 +856,7 @@ int32_t main(
     if (strcmp(init_arg, "-V") == 0 || strcmp(init_arg, "--version") == 0) {
       display_ver();
 
-      #ifdef _WIN32
+      #if defined(_WIN32)
         disable_ansi();
       #endif
 
@@ -891,7 +891,7 @@ int32_t main(
       free_char_2d(env_args, &n_env_args);
 
       printf(KBLU "\nRun \"%sarcus%s install {--ignore ...}%s\" to install packages\n", KMAG, KCYN, KBLU);
-      #ifdef _WIN32
+      #if defined(_WIN32)
         disable_ansi();
       #endif
       exit(0);
@@ -925,7 +925,7 @@ int32_t main(
 
       bool PRINTED_INS_SUCC = false;
 
-      #ifdef __unix__
+      #if defined(__unix__) || defined(__linux__)
         if (has_lolcat() && has_neofetch()) {
           system("neofetch | lolcat; echo -e \"< INSTALLATION SUCCESSFUL >\nEnjoy! :)\" | lolcat");
           PRINTED_INS_SUCC = true;
@@ -937,7 +937,7 @@ int32_t main(
       if (!PRINTED_INS_SUCC)
         printf(KGRN "< INSTALLATION SUCCESSFUL >\nEnjoy! :)\n");
 
-      #ifdef _WIN32
+      #if defined(_WIN32)
         disable_ansi();
       #endif
 
@@ -950,7 +950,7 @@ int32_t main(
   free_char_2d(packages, &n_packages);
   free_char_2d(env_args, &n_env_args);
 
-  #ifdef _WIN32
+  #if defined(_WIN32)
     disable_ansi();
   #endif
 

--- a/arcus.c
+++ b/arcus.c
@@ -1,362 +1,853 @@
 /**
- * Programmed by Sigma 
- * Last Updated: 13th January, 2024
- * Arcus
- * > Scriptable Package Manager
+ * @name Arcus
+ * @author https://github.com/SigmaEG/Arcus
+ * @note Last Updated: 13th January, 2024
+ * @note Script Manager
  */
 
 #include "arcus.h"
 
-#ifdef _WIN32
-  #ifdef ARCUS_INITED_WIN_TERM_PROC
-    static HANDLE stdoutHandle;
-    static DWORD outModeInit;
+#pragma region LOCAL FUNCTION DECLARATIONS
 
-    void setupConsole(void) {
-      DWORD outMode = 0;
-      stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-      
-      if(stdoutHandle == INVALID_HANDLE_VALUE)
-        exit(GetLastError());
-      
-      if(!GetConsoleMode(stdoutHandle, &outMode))
-        exit(GetLastError());
-      
-      outModeInit = outMode;
-      
-      // Enable ANSI escape codes
-      outMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-      
-      if(!SetConsoleMode(stdoutHandle, outMode))
-        exit(GetLastError());
-    }
-    
-    void restoreConsole(void) {
-      // Reset colors
-      printf("\x1b[0m");	
-    
-      // Reset console mode
-      if(!SetConsoleMode(stdoutHandle, outModeInit))
-        exit(GetLastError());
-    }
-  #else
-    void setupConsole(void) {}
-    
-    void restoreConsole(void) {
-        // Reset colors
-        printf("\x1b[0m");
-    }
-  #endif
-  /* Source-End */
+  /**
+   * @author https://github.com/SigmaEG/Arcus/Arcus
+   * @brief Strips trailing characters from a string
+   * 
+   * @param string > Reference to a string to be stripped
+   * @param to_strip > Char to strip from `string`
+   * @param from_end > Whether to strip backwards or from the front
+   * 
+   * @return `void`
+  */
+  static
+  void
+  strip_trailing_char(
+    char** string,
+    char to_strip,
+    bool from_end
+  ) {
+    if (string == NULL)
+      return;
 
-  int32_t setenv(const char *name, const char *value, int32_t overwrite) {   
-    int32_t errcode = 0;
-    
-    if (!overwrite) {
-      size_t envsize = 0;
-      errcode = getenv_s(&envsize, NULL, 0, name);
-      
-      if (errcode || envsize)
-        return errcode;
-    }
+    if (*string == NULL)
+      return;
 
-    return _putenv_s(name, value);
+    int32_t string_len = strlen(*string);
+    int32_t new_pos = -1;
+    
+    if (!from_end) {
+      bool char_found = false;
+
+      for (int32_t idx = 0; idx < string_len; ++idx) {
+        new_pos = idx;
+
+        if (!char_found) {
+          if ((*string)[idx] == to_strip)
+            char_found = true;
+        }
+
+        if ((*string)[idx] != to_strip)
+          break;
+      }
+
+      if (new_pos != -1 && char_found) {
+        char* new_alloc = (char*)calloc((string_len - new_pos) + 1, sizeof(char));
+
+        if (new_alloc != NULL) {
+          char* read_from = *string + new_pos;
+
+          snprintf(new_alloc, (string_len - new_pos) + 1, "%s", read_from);
+
+          free(*string);
+          *string = new_alloc;
+
+          return;
+        }
+      }
+    } else {
+      bool char_found = false;
+
+      for (int32_t idx = string_len - 1; idx > 0; --idx) {
+        new_pos = idx;
+
+        if (!char_found) {
+          if ((*string)[idx] == to_strip)
+            char_found = true;
+        }
+
+        if ((*string)[idx] != to_strip)
+          break;
+      }
+
+      if (char_found) {
+        char* new_alloc = (char*)calloc(new_pos + 2, sizeof(char));
+
+        if (new_alloc != NULL) {
+          snprintf(new_alloc, new_pos + 2, "%s", *string);
+
+          free(*string);
+          *string = new_alloc;
+
+          return;
+        }
+      }
+    }
   }
 
-  int32_t unsetenv(const char* name) {
-    return setenv(name, "", 1);
+  /**
+   * @author https://github.com/SigmaEG/Arcus/Arcus
+   * @brief Frees a 2D C-Style String Array
+   * 
+   * @param char_2d > 2D C-Style String Array to `free(...)`
+   * @param n_elements > Number of Elements inside `char*** char_2d`
+   * 
+   * @return `void`
+  */
+  static
+  void
+  free_char_2d(
+    char*** char_2d,
+    int32_t* n_elements
+  ) {
+    if (char_2d == NULL || n_elements == NULL)
+      return;
+
+    for (int32_t array_idx = 0; array_idx < *n_elements; ++array_idx) {
+      char** array = char_2d[array_idx];
+
+      if (array != NULL) {
+        for (int32_t data_idx = 0; data_idx < 2; ++data_idx) {
+          char* data = array[data_idx];
+
+          if (data != NULL) {
+            free(data);
+            data = NULL;
+          }
+        }
+
+        free(array);
+        array = NULL;
+      }
+    }
+
+    free(char_2d);
+    char_2d = NULL;
+    *n_elements = 0;
   }
-#endif
 
-// Checks whether lolcat is found in /usr/bin for LOLCAT_SUPPORT
-bool
-has_lolcat(void) {
-  #ifdef __unix__
-    if (LOLCAT_SUPPORT)
-      return access("/usr/bin/lolcat", F_OK) == 0 ? true : false;
-  #endif
+  /**
+   * @author https://github.com/SigmaEG/Arcus/Arcus
+   * @brief Parses Arcus files efficiently
+   * 
+   * @param file > Arcus file reference
+   * @param size_out > Reference to an `int32_t` that will store the amount of elements in `return`
+   * 
+   * @return `char***` - > A 2D C-Style String Array containing Arcus data
+  */
+  static
+  char***
+  parse(
+    FILE* file,
+    int32_t* size_out
+  ) {
+    if (file == NULL)
+      return NULL;
 
-  return false;
-}
+    char*** parsed_data = NULL;
+    int32_t data_size = 0;
 
-/**
- * @author Sigma
- * @param size_out > Writes size of line (including null-terminator) if non-NULL;
- * @param remove_delim > Whether you want to include the delimiter in the line returned;
- * @param delimiter > Specify a delimiter (character to read up to);
- * @param fstream > Stream to read (e.g stdin, stdout);
-*/
-char*
-arcus_getline(
-  size_t* size_out,
-  const bool remove_delim,
-  const char delimiter,
-  FILE* fstream
-) {
-  char* line = (char*)malloc(8 * sizeof(char));
-  size_t line_sz = 8;
+    char* line = NULL;
+    int32_t line_size;
 
-  if (line == NULL) {
-    *size_out = 0;
-    return NULL;
-  }
+    bool parsing_package = false;
 
-  char character;
-  size_t read_count = 0;
+    char* header = NULL;
+    char* body = NULL;
 
-  while (fread(&character, 1, sizeof(char), fstream) > 0) {
-    if ((read_count + 1) == line_sz) {
-      char* line_realloc = (char*)realloc(line, (line_sz * 2) * sizeof(char));
+    while ((line = arcus_getline(
+      &line_size,
+      true,
+      '\n',
+      file
+    )) != NULL) {
+      if (line_size <= 0) {
+        if (line != NULL) {
+          free(line);
+          line = NULL;
+        }
 
-      if (line_realloc == NULL)
+        continue;
+      }
+
+      if (strcmp(line, "{") == 0 || strcmp(line, "},") == 0) {
+        parsing_package = true;
+        
+        if (line != NULL) {
+          free(line);
+          line = NULL;
+        }
+
+        continue;
+      }
+
+      if (strcmp(line, "}") == 0) {
+        parsing_package = false;
+
+        if (line != NULL) {
+          free(line);
+          line = NULL;
+        }
+
         break;
+      }
 
-      line = line_realloc;
-      line_sz *= 2;
+      if (parsing_package) {
+        if (header == NULL && body == NULL) {
+          strip_trailing_char(
+            &line,
+            ' ',
+            false
+          );
+          strip_trailing_char(
+            &line,
+            '"',
+            false
+          );
+          strip_trailing_char(
+            &line,
+            ' ',
+            true
+          );
+          strip_trailing_char(
+            &line,
+            ',',
+            true
+          );
+          strip_trailing_char(
+            &line,
+            '"',
+            true
+          );
 
-      line[line_sz - 1] = '\0';
+          header = line;
 
-      if (size_out != NULL)
-        *size_out = line_sz - 1;
+          continue;
+        }
+
+        if (body == NULL && header != NULL) {
+          strip_trailing_char(
+            &line,
+            ' ',
+            false
+          );
+          strip_trailing_char(
+            &line,
+            '"',
+            false
+          );
+          strip_trailing_char(
+            &line,
+            ' ',
+            true
+          );
+          strip_trailing_char(
+            &line,
+            '"',
+            true
+          );
+
+          body = line;
+        }
+
+        if (header != NULL && body != NULL) {
+          if (parsed_data == NULL) {
+            parsed_data = (char***)calloc(1, sizeof(char**));
+
+            if (parsed_data != NULL) {
+              parsed_data[0] = (char**)calloc(2, sizeof(char*));
+              
+              if (parsed_data[0] != NULL) {
+                parsed_data[0][0] = header;
+                parsed_data[0][1] = body;
+
+                data_size = 1;
+              } else {
+                free(parsed_data);
+                parsed_data = NULL;
+                data_size = 0;
+
+                free(header);
+                free(body);
+
+                continue;
+              }
+            } else {
+              free(header);
+              free(body);
+
+              continue;
+            }
+          } else {
+            char*** re_alloc = (char***)realloc(parsed_data, (data_size + 1) * sizeof(char**));
+          
+            if (re_alloc != NULL) {
+              parsed_data = re_alloc;
+              parsed_data[data_size] = (char**)calloc(2, sizeof(char*));
+              
+              if (parsed_data[data_size] != NULL) {
+                parsed_data[data_size][0] = header;
+                parsed_data[data_size][1] = body;
+
+                ++data_size;
+              } else {
+                parsed_data = (char***)realloc(parsed_data, data_size * sizeof(char**));
+
+                free(header);
+                free(body);
+
+                continue;
+              }
+            } else {
+              free(header);
+              free(body);
+
+              continue;
+            }
+          }
+        }
+
+        header = NULL;
+        body = NULL;
+
+        continue;
+      }
     }
-  
-    ++read_count;
-    line[read_count - 1] = character;
-
-    if (character == delimiter)
-      break;
-  }
-
-  if (read_count == 1) {
-    free(line);
-    line = NULL;
 
     if (size_out != NULL)
-      *size_out = 0;
+      *size_out = data_size;
 
-    return NULL;
+    fclose(file);
+
+    return parsed_data;
   }
 
-  if (!remove_delim)
-    read_count += 1;
+#pragma endregion LOCAL FUNCTION DECLARATIONS
 
-  if (read_count != line_sz) {
-    char* line_realloc = (char*)realloc(line, line_sz * sizeof(char));
+#pragma region FUNCTION DECLARATIONS
 
-    if (line_realloc != NULL)
-      line = line_realloc;
-  }
+  bool
+  pathexists(const char* path) {
+    struct stat file;
 
-  line_sz = read_count;
-  line[line_sz - 1] = '\0';
-
-  if (size_out != NULL)
-    *size_out = line_sz;
-
-  return line;
-}
-
-// Creates an environment variable for the current session
-bool
-set_env(
-  const char* name,
-  const char* value
-) {
-  if (has_lolcat()) {
-    char* lolcat = (char*)calloc(strlen("echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
-    sprintf(lolcat, "echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
-
-    system(lolcat);
-    free(lolcat);
-  }
-  else
-    printf(KBLU "< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KBLU);
-
-  if (setenv(name, value, 1) == 1) {
-    fprintf(stderr, KRED "< FAILED TO ALLOCATE TEMPORARY ENVIRONMENT VARIABLE %s\"%s\"%s >\n", KMAG, name, KBLU);
+    if (stat(path, &file) == 0)
+      return true;
 
     return false;
   }
-  
-  if (has_lolcat()) {
-    char* lolcat = (char*)calloc(strlen("echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
-    sprintf(lolcat, "echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
 
-    system(lolcat);
-    free(lolcat);
-  }
-  else
-    printf(KGRN "< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KGRN);
+  #pragma region OS-SPECIFIC DECLARATIONS
 
-  return true;
-}
+    #ifdef __unix__
+      bool
+      has_neofetch(void) {
+        if (pathexists("/usr/local/bin/neofetch")
+            || pathexists("/usr/bin/neofetch")
+            || pathexists("/var/lib/flatpak/exports/bin/neofetch")
+        ) {
+          return true;
+        }
 
-// Initializes environment variables for Package Installation
-void
-init_env_args(const bool remove) {
-  for (size_t arg_idx = 0; arg_idx < n_env_args; ++arg_idx) {
-    if (!remove) {
-      if (!set_env(env_args[arg_idx][0], env_args[arg_idx][1])) {
-        fprintf(stderr, KRED "< ERROR : QUITTING ARCUS >\n");
-        exit(1);
+        return false;
       }
-    } else
-      unsetenv(env_args[arg_idx][0]);
-  }
-}
 
-// Checks whether a package has been specified by the {--ignore ...} switch
-bool
-is_ignored(
-  const char* package,
-  const char** ignore,
-  const size_t n_ignore
-) {
-  for (size_t ignore_idx = 0; ignore_idx < n_ignore; ++ignore_idx) {
-    if (strcmp(package, ignore[ignore_idx]) == 0)
-      return true;
-  }
+      bool
+      has_lolcat(void) {
+        if (pathexists("/usr/local/bin/lolcat")
+            || pathexists("/usr/bin/lolcat")
+            || pathexists("/var/lib/flatpak/exports/bin/lolcat")
+        ) {
+          if (LOLCAT_SUPPORT)
+            return true;
+        }
 
-  return false;
-}
+        return false;
+      }
+    #endif
 
-// Lists packages to be installed, tagged with [IGNORED] if specified by {--ignore ...} switch
-void
-list_packages(
-  const char** ignore,
-  const size_t n_ignore
-) {
-  printf(KGRN "Packages to Install:\n");
+    #ifdef _WIN32
+      // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
+      #ifdef ARCUS_INITED_WIN_TERM_PROC
+        static HANDLE stdout_handle;
+        static DWORD outmode_init;
 
-  for (size_t pkg_idx = 0; pkg_idx < n_packages; ++pkg_idx) {
-    const char* pkg_name = packages[pkg_idx][0];
-    char* pkg_how = NULL;
-    bool ignored = is_ignored(pkg_name, ignore, n_ignore);
+        void
+        enable_ansi(void) {
+          DWORD out_mode = 0;
+          stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+          
+          if (stdout_handle == INVALID_HANDLE_VALUE)
+            exit(GetLastError());
+          
+          if (!GetConsoleMode(stdout_handle, &out_mode))
+            exit(GetLastError());
+          
+          outmode_init = out_mode;
+          
+          // Enable ANSI escape codes
+          out_mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+          
+          if (!SetConsoleMode(stdout_handle, out_mode))
+            exit(GetLastError());
+        }
+        
+        void
+        disable_ansi(void) {
+          // ANSI \Esc[0m (Normal)
+          printf("\x1b[0m");	
+        
+          if(!SetConsoleMode(stdout_handle, outmode_init))
+            exit(GetLastError());
+        }
+      #else
+        void
+        enable_ansi(void) {}
+        
+        void
+        disable_ansi(void) {
+            // ANSI \Esc[0m (Normal)
+            printf("\x1b[0m");
+        }
+      #endif
+      /* Source-End */
 
-    if (strstr(packages[pkg_idx][1], "PACMAN") != NULL)
-      pkg_how = "PACMAN";
-    else if (strstr(packages[pkg_idx][1], "YAY") != NULL)
-      pkg_how = "YAY-AUR";
-    else if (strstr(packages[pkg_idx][1], "flatpak install") != NULL)
-      pkg_how = "FLATPAK";
-    else if (strstr(packages[pkg_idx][1], "git clone") != NULL || strstr(packages[pkg_idx][1], "github") != NULL)
-      pkg_how = "GITHUB";
-    else
-      pkg_how = "SELF-DEFINED";
+      int32_t setenv(const char* name, const char* value, int32_t overwrite) {   
+        int32_t errcode = 0;
+        
+        if (!overwrite) {
+          size_t envsize = 0;
+          errcode = getenv_s(&envsize, NULL, 0, name);
+          
+          if (errcode || envsize)
+            return errcode;
+        }
 
-    printf(KCYN "[%s]:%s %s%s%s\n", pkg_how, KNRM, KMAG, pkg_name, ignored ? KYEL " [IGNORED]" : "");
-  }
+        return _putenv_s(name, value);
+      }
 
-  printf(KYEL "\n%zu Package%s Ignored%s\n", n_ignore, n_ignore == 1 ? "" : "(s)", n_ignore == 0 ? ", See \"arcus {-h --help}\"" : "");
-}
+      int32_t unsetenv(const char* name) {
+        return setenv(name, "", 1);
+      }
+    #endif
 
-// Installs packages that aren't marked with by the {--ignore ...} switch
-void
-install_packages(
-  const char** ignore,
-  const size_t n_ignore
-) {
-  list_packages(ignore, n_ignore);
+  #pragma endregion OS-SPECIFIC DECLARATIONS
 
-  printf(KBLU "\nAre you sure you'd like to continue to installation? (%sY%s/%sn%s):%s ", KGRN, KBLU, KRED, KBLU, KGRN);
+  char*
+  arcus_getline(
+    int32_t* size_out,
+    const bool remove_delim,
+    const char delimiter,
+    FILE* fstream
+  ) {
+    char* line = (char*)malloc(8 * sizeof(char));
+    int32_t line_sz = 8;
 
-  char* confirmation = arcus_getline(NULL, true, '\n', stdin);
-
-  if (confirmation != NULL) {
-    if (tolower(confirmation[0]) != 'y') {
-      printf(KRED "\n< INSTALLATION CANCELED >\n");
-      free(ignore);
-
-      exit(0);
+    if (line == NULL) {
+      *size_out = 0;
+      return NULL;
     }
 
-    free(confirmation);
-  }
+    char character;
+    int32_t read_count = 0;
 
-  printf(KGRN "Beginning installation...\n\n");
+    while (fread(&character, 1, sizeof(char), fstream) > 0) {
+      if ((read_count + 1) == line_sz) {
+        char* line_realloc = (char*)realloc(line, (line_sz * 2) * sizeof(char));
 
-  init_env_args(false);
+        if (line_realloc == NULL)
+          break;
 
-  printf("\n");
+        line = line_realloc;
+        line_sz *= 2;
 
-  for (size_t pkg_idx = 0; pkg_idx < n_packages; ++pkg_idx) {
-    const char* pkg_name = packages[pkg_idx][0];
-    bool ignored = is_ignored(pkg_name, ignore, n_ignore);
+        line[line_sz - 1] = '\0';
 
-    if (ignored) {
-      printf(KYEL "< IGNORING : %s >\n", pkg_name);
-      continue;
+        if (size_out != NULL)
+          *size_out = line_sz - 1;
+      }
+    
+      ++read_count;
+      line[read_count - 1] = character;
+
+      if (character == delimiter)
+        break;
     }
 
-    set_env("ARCUS_PACKAGES", pkg_name);
+    if (read_count == 1) {
+      free(line);
+      line = NULL;
 
-    int32_t ret = system(packages[pkg_idx][1]);
-    if (ret == 130 || ret == 2 || ret == 33280) {
-      printf(KRED "\n< INSTALLATION INTERRUPTED >\n\n");
-      free(ignore);
+      if (size_out != NULL)
+        *size_out = 0;
 
-      exit(2);
+      return NULL;
+    }
+
+    if (!remove_delim)
+      read_count += 1;
+
+    if (read_count != line_sz) {
+      char* line_realloc = (char*)realloc(line, line_sz * sizeof(char));
+
+      if (line_realloc != NULL)
+        line = line_realloc;
+    }
+
+    line_sz = read_count;
+    line[line_sz - 1] = '\0';
+
+    if (size_out != NULL)
+      *size_out = line_sz;
+
+    return line;
+  }
+
+  bool
+  set_env(
+    const char* name,
+    const char* value
+  ) {
+    #ifdef __unix__
+      if (has_lolcat()) {
+        char* lolcat = (char*)calloc(strlen("echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
+        sprintf(lolcat, "echo \"< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
+
+        system(lolcat);
+        free(lolcat);
+      } else
+        printf(KBLU "< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KBLU);
+    #else
+      printf(KBLU "< ALLOCATING TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KBLU);
+    #endif
+
+    if (setenv(name, value, 1) == 1) {
+      fprintf(stderr, KRED "< FAILED TO ALLOCATE TEMPORARY ENVIRONMENT VARIABLE %s\"%s\"%s >\n", KMAG, name, KBLU);
+
+      return false;
+    }
+    
+    #ifdef __unix__
+      if (has_lolcat()) {
+        char* lolcat = (char*)calloc(strlen("echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE :  =  >\" | lolcat") + strlen(name) + strlen(value) + 1, sizeof(char));
+        sprintf(lolcat, "echo \"< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s=%s >\" | lolcat", name, value);
+
+        system(lolcat);
+        free(lolcat);
+      }
+      else
+        printf(KGRN "< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KGRN);
+    #else
+        printf(KGRN "< SUCCESSFULLY ALLOCATED TEMPORARY ENVIRONMENT VARIABLE : %s%s=%s%s >\n", KMAG, name, value, KGRN);
+    #endif
+
+
+    return true;
+  }
+
+  void
+  init_env_args(const bool remove) {
+    for (int32_t arg_idx = 0; arg_idx < n_env_args; ++arg_idx) {
+      if (!remove) {
+        if (!set_env(env_args[arg_idx][0], env_args[arg_idx][1])) {
+          fprintf(stderr, KRED "< ERROR : QUITTING ARCUS >\n");
+          exit(1);
+        }
+      } else
+        unsetenv(env_args[arg_idx][0]);
     }
   }
 
-  init_env_args(true);
-  unsetenv("ARCUS_PACKAGES");
+  bool
+  is_ignored(
+    const char* package,
+    const char** ignore,
+    const int32_t n_ignore
+  ) {
+    for (int32_t ignore_idx = 0; ignore_idx < n_ignore; ++ignore_idx) {
+      if (strcmp(package, ignore[ignore_idx]) == 0)
+        return true;
+    }
 
-  printf("\n");
-}
-
-// Compiles an ignore list from argv
-char**
-gen_ignore_list(
-  char** argv,
-  const size_t start_idx,
-  const size_t end_idx
-) {
-  char** ignore_list = (char**)calloc((end_idx + 1) - start_idx, sizeof(char*));
-
-  if (ignore_list != NULL) {
-    for (size_t idx = start_idx; idx < end_idx + 1; ++idx)
-      ignore_list[idx - start_idx] = argv[idx];
+    return false;
   }
 
-  return ignore_list;
-}
+  void
+  list_packages(
+    const char** ignore,
+    const int32_t n_ignore
+  ) {
+    printf(KGRN "Packages to Install:\n");
 
-// Displays the Arcus Help Information
-void
-display_help(void) {
-  printf(
-    "%susage:%s arcus %s<operation> [...]%s\n"
-    "%soperations:%s\n"
-    "\tarcus %s{-h --help}%s\n"
-    "\tarcus %s{-V --version}%s\n"
-    "\tarcus list %s{--ignore ...}%s %s(arguments after --ignore are listed as ignored packages, separated by a whitespace)%s\n"
-    "\tarcus install %s{--ignore ...}%s %s(may require root permissions, arguments after --ignore are listed as ignored packages, separated by a whitespace)\n\n",
-    KYEL, KMAG, KCYN, KMAG, KYEL, KMAG, KCYN, KMAG, KCYN, KMAG, KCYN, KMAG, KYEL, KMAG, KCYN, KMAG, KYEL
-  );
-}
+    for (int32_t pkg_idx = 0; pkg_idx < n_packages; ++pkg_idx) {
+      const char* pkg_name = packages[pkg_idx][0];
+      char* pkg_how = NULL;
+      bool ignored = is_ignored(pkg_name, ignore, n_ignore);
 
-// Displays Arcus Version Information
-void
-display_ver(void) {
-  printf(KMAG
-    "  Arcus %s" ARCUS_VER "\n"
-    "  Copyright (C) 2015 - 2024 SigmaTech\n\n"
-    "  %sThis program may be freely redistributed under the terms of the GNU General Public License.\n%s"
-    SIGMA_SYMBOL_ASCII,
-    KYEL, KBLU, KMAG
-  );
-}
+      if (strstr(packages[pkg_idx][1], "PACMAN") != NULL)
+        pkg_how = "PACMAN";
+      else if (strstr(packages[pkg_idx][1], "YAY") != NULL)
+        pkg_how = "YAY-AUR";
+      else if (strstr(packages[pkg_idx][1], "flatpak install") != NULL)
+        pkg_how = "FLATPAK";
+      else if (strstr(packages[pkg_idx][1], "git clone") != NULL || strstr(packages[pkg_idx][1], "github") != NULL)
+        pkg_how = "GITHUB";
+      else
+        pkg_how = "SELF-DEFINED";
 
-int main(
-  int argc,
-  char** argv
+      printf(KCYN "[%s]:%s %s%s%s\n", pkg_how, KNRM, KMAG, pkg_name, ignored ? KYEL " [IGNORED]" : "");
+    }
+
+    printf(KYEL "\n%d Package%s Ignored%s\n", n_ignore, n_ignore == 1 ? "" : "(s)", n_ignore == 0 ? ", See \"arcus {-h --help}\"" : "");
+  }
+
+  void
+  install_packages(
+    const char** ignore,
+    const int32_t n_ignore
+  ) {
+    list_packages(ignore, n_ignore);
+
+    printf(KBLU "\nAre you sure you'd like to continue to installation? (%sY%s/%sn%s):%s ", KGRN, KBLU, KRED, KBLU, KGRN);
+
+    char* confirmation = arcus_getline(NULL, true, '\n', stdin);
+
+    if (confirmation != NULL) {
+      if (tolower(confirmation[0]) != 'y') {
+        printf(KRED "\n< INSTALLATION CANCELED >\n");
+        free(ignore);
+
+        exit(0);
+      }
+
+      free(confirmation);
+    }
+
+    printf(KGRN "Beginning installation...\n\n");
+
+    init_env_args(false);
+
+    printf("\n");
+
+    for (int32_t pkg_idx = 0; pkg_idx < n_packages; ++pkg_idx) {
+      const char* pkg_name = packages[pkg_idx][0];
+      bool ignored = is_ignored(pkg_name, ignore, n_ignore);
+
+      if (ignored) {
+        printf(KYEL "< IGNORING : %s >\n", pkg_name);
+        continue;
+      }
+
+      set_env("ARCUS_PACKAGES", pkg_name);
+
+      int32_t ret = system(packages[pkg_idx][1]);
+      if (ret == 130 || ret == 2 || ret == 33280) {
+        printf(KRED "\n< INSTALLATION INTERRUPTED >\n\n");
+        free(ignore);
+
+        exit(2);
+      }
+    }
+
+    init_env_args(true);
+    unsetenv("ARCUS_PACKAGES");
+
+    printf("\n");
+  }
+
+  void
+  display_help(void) {
+    printf(
+      "%susage:%s arcus %s<operation> [...]%s\n"
+      "%soperations:%s\n"
+      "\tarcus %s{-h --help}%s\n"
+      "\tarcus %s{-V --version}%s\n"
+      "\tarcus list %s{--ignore ...}%s %s(arguments after --ignore are listed as ignored packages, separated by a whitespace)%s\n"
+      "\tarcus install %s{--ignore ...}%s %s(may require root permissions, arguments after --ignore are listed as ignored packages, separated by a whitespace)\n\n",
+      KYEL, KMAG, KCYN, KMAG, KYEL, KMAG, KCYN, KMAG, KCYN, KMAG, KCYN, KMAG, KYEL, KMAG, KCYN, KMAG, KYEL
+    );
+  }
+
+  void
+  display_ver(void) {
+    printf(KMAG
+      "  Arcus %s" ARCUS_VER "\n"
+      "  Copyright (C) 2015 - 2024 SigmaTech\n\n"
+      "  %sThis program may be freely redistributed under the terms of the GNU General Public License.\n%s"
+      SIGMA_SYMBOL_ASCII,
+      KYEL, KBLU, KMAG
+    );
+  }
+
+  char***
+  parse_pkgs(int32_t* size_out) {
+    if (!pathexists("arcus_config")) {
+      fprintf(stderr, KRED "< FAILED TO STAT DIRECTORY : arcus_config >");
+
+      return NULL;
+    }
+
+    if (!pathexists("arcus_config/arcus.pkgs")) {
+      fprintf(stderr, KRED "< FAILED TO STAT PACKAGES FILE : arcus_config/arcus.pkgs >");
+
+      return NULL;
+    }
+
+    FILE* file = fopen("arcus_config/arcus.pkgs", "r");
+
+    if (file == NULL)
+      return NULL;
+
+    return parse(file, size_out);
+  }
+
+  char***
+  parse_envs(int32_t* size_out) {
+    if (!pathexists("arcus_config")) {
+      fprintf(stderr, KRED "< FAILED TO STAT DIRECTORY : arcus_config >");
+
+      return NULL;
+    }
+
+    if (!pathexists("arcus_config/arcus.envs")) {
+      fprintf(stderr, KRED "< FAILED TO STAT ENVIRONMENT VARIABLES FILE : arcus_config/arcus.envs >");
+
+      return NULL;
+    }
+
+    FILE* file = fopen("arcus_config/arcus.envs", "r");
+
+    if (file == NULL)
+      return NULL;
+
+    return parse(file, size_out);
+  }
+
+  int32_t
+  parse_command(const char* cmd_name) {
+    bool CHECK_SUB = false;
+
+    if (strstr(cmd_name, "-") != NULL)
+      CHECK_SUB = true;
+
+    for (int32_t cmd_idx = 0; cmd_idx < n_commands; ++cmd_idx) {
+      if (strcmp(commands[cmd_idx], cmd_name) == 0)
+        return CHECK_SUB ? RET_SUB_COMMAND : RET_BASE_COMMAND;
+    }
+
+    return -1;
+  }
+
+  const char**
+  parse_arguments(
+    const char** argv,
+    const int32_t n_max_argv,
+    const char* arg_name,
+    const int32_t n_expected_params,
+    int32_t* n_params_out
+  ) {
+    if (parse_command(arg_name) == -1)
+      return NULL; // Invalid Command to Parse
+
+    printf("< BEGINNING ARGUMENT PARSER : %s >\n", arg_name);
+
+    const char** arg_params = NULL;
+    int32_t n_arg_params = 0;
+    bool dynamic = false;
+
+    if (n_expected_params > 0) {
+      arg_params = (const char**)calloc(n_expected_params, sizeof(const char*));
+
+      if (arg_params == NULL) {
+        fprintf(stderr, KRED "< FAILED TO ALLOCATE %zu byte(s) FOR ARG_PARAMS >\n", n_expected_params * sizeof(const char*));
+
+        if (n_params_out != NULL)
+          *n_params_out = 0;
+
+        return NULL;
+      }
+    } else if (n_expected_params == -1) {
+      printf("dynamic\n");
+      dynamic = true;
+      arg_params = (const char**)calloc(1, sizeof(const char*));
+      
+      if (arg_params == NULL) {
+        fprintf(stderr, KRED "< FAILED TO ALLOCATE %zu byte(s) FOR ARG_PARAMS >\n", sizeof(const char*));
+
+        if (n_params_out != NULL)
+          *n_params_out = 0;
+
+        return NULL;
+      }
+    }
+
+    bool arg_found = false;
+    int32_t params_read = 0;
+
+    for (int32_t param_idx = 0; param_idx < n_max_argv; ++param_idx) {
+      if (!dynamic && params_read == n_arg_params)
+        break;
+
+      const char* param = argv[param_idx];
+
+      if (!arg_found) {
+        if (strcmp(param, arg_name) == 0) {
+          arg_found = true;
+          continue;
+        }
+      }
+
+      if (parse_command(param) == -1) {
+        // Parsing Valid Parameter (non-command)
+
+        if (dynamic) {
+          const char** re_alloc = (char const**)realloc(arg_params, (params_read + 1) * sizeof(const char*));
+
+          if (re_alloc != NULL) {
+            arg_params = re_alloc;
+
+            if (n_params_out != NULL)
+              *n_params_out = params_read + 1;
+          }
+          else {
+            fprintf(stderr, KRED "< FAILED TO ALLOCATE %zu byte(s) FOR ARG_PARAMS >\n", sizeof(char*));
+            
+            break;
+          }
+        }
+
+        ++params_read;
+        arg_params[params_read - 1] = param;
+      }
+      else
+        break;
+    }
+
+    if (n_params_out != NULL)
+      *n_params_out = params_read;
+
+    return arg_params;
+  }
+
+#pragma endregion FUNCTION DECLARATIONS
+
+int32_t main(
+  int32_t argc,
+  const char** argv
 ) {
   #ifdef _WIN32
-    setupConsole();
+    enable_ansi();
   #endif
 
-  char* init_arg = NULL;
+  const char* init_arg = NULL;
 
   if (argc >= 2)
     init_arg = argv[1];
@@ -366,68 +857,88 @@ int main(
       display_ver();
 
       #ifdef _WIN32
-        restoreConsole();
+        disable_ansi();
       #endif
 
       exit(0);
     }
 
     if (strcmp(init_arg, "list") == 0) {
-      char** ignore_list = NULL;
-      size_t ignores = 0;
+      packages = parse_pkgs(&n_packages);
+      env_args = parse_envs(&n_env_args);
 
-      if (argc >= 4) {
-        char* is_ignore = strcmp(argv[2], "--ignore") == 0 ? argv[2] : NULL;
+      if (packages == NULL || env_args == NULL) {
+        printf(
+          KRED "< FAILED TO PARSE %s%s%s >",
+          packages == NULL ? "PACKAGES" : "",
+          packages == NULL && env_args == NULL ? " AND " : "",
+          env_args == NULL ? "ENVIRONMENT VARIABLES" : ""
+        );
 
-        if (is_ignore != NULL) {
-          ignores = argc - 3;
-          ignore_list = gen_ignore_list(argv, 3, argc - 1);
-        }
+        exit(1);
       }
+
+      int32_t ignores = 0;
+      const char** ignore_list = parse_arguments(argv + 2, argc - 2, "--ignore", -1, &ignores);
 
       list_packages(
         (const char**)ignore_list,
         ignores
       );
+
       free(ignore_list);
-    
+      free_char_2d(packages, &n_packages);
+      free_char_2d(env_args, &n_env_args);
+
       printf(KBLU "\nRun \"%sarcus%s install {--ignore ...}%s\" to install packages\n", KMAG, KCYN, KBLU);
       #ifdef _WIN32
-        restoreConsole();
+        disable_ansi();
       #endif
       exit(0);
     }
 
     if (strcmp(init_arg, "install") == 0) {
-      char** ignore_list = NULL;
-      size_t ignores = 0;
+      packages = parse_pkgs(&n_packages);
+      env_args = parse_envs(&n_env_args);
 
-      if (argc >= 4) {
-        char* is_ignore = strcmp(argv[2], "--ignore") == 0 ? argv[2] : NULL;
+      if (packages == NULL || env_args == NULL) {
+        printf(
+          KRED "< FAILED TO PARSE %s%s%s >",
+          packages == NULL ? "PACKAGES" : "",
+          packages == NULL && env_args == NULL ? " AND " : "",
+          env_args == NULL ? "ENVIRONMENT VARIABLES" : ""
+        );
 
-        if (is_ignore != NULL) {
-          ignores = argc - 3;
-          ignore_list = gen_ignore_list(argv, 3, argc - 1);
-        }
+        exit(1);
       }
+
+      int32_t ignores = 0;
+      const char** ignore_list = parse_arguments(argv + 2, argc - 2, "--ignore", -1, &ignores);
 
       install_packages(
         (const char**)ignore_list,
         ignores
       );
       free(ignore_list);
+      free_char_2d(packages, &n_packages);
+      free_char_2d(env_args, &n_env_args);
+
+      bool PRINTED_INS_SUCC = false;
 
       #ifdef __unix__
-        if (has_lolcat() && access("/usr/bin/neofetch", F_OK) == 0)
+        if (has_lolcat() && has_neofetch()) {
           system("neofetch | lolcat; echo -e \"< INSTALLATION SUCCESSFUL >\nEnjoy! :)\" | lolcat");
-        else if (access("/usr/bin/neofetch", F_OK) == 0) {
-          system("neofetch");
-          printf(KGRN "< INSTALLATION SUCCESSFUL >\nEnjoy! :)\n");
+          PRINTED_INS_SUCC = true;
         }
+        else if (has_neofetch())
+          system("neofetch");
       #endif
 
+      if (!PRINTED_INS_SUCC)
+        printf(KGRN "< INSTALLATION SUCCESSFUL >\nEnjoy! :)\n");
+
       #ifdef _WIN32
-        restoreConsole();
+        disable_ansi();
       #endif
 
       exit(0);
@@ -436,8 +947,11 @@ int main(
 
   display_help();
 
+  free_char_2d(packages, &n_packages);
+  free_char_2d(env_args, &n_env_args);
+
   #ifdef _WIN32
-    restoreConsole();
+    disable_ansi();
   #endif
 
   exit(0);

--- a/arcus.h
+++ b/arcus.h
@@ -1,517 +1,313 @@
 /**
- * Programmed by Sigma 
- * Last Updated: 13th January, 2024
- * Arcus
- * > Scriptable Package Manager
+ * @name Arcus
+ * @author https://github.com/SigmaEG/Arcus
+ * @note Last Updated: 13th January, 2024
+ * @note Script Manager
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <ctype.h>
+#pragma region INCLUDES
 
-#ifdef __unix__
-  #include <unistd.h>
-#endif
+  #include <stdlib.h>
+  #include <stdio.h>
+  #include <stdbool.h>
+  #include <stdint.h>
+  #include <string.h>
+  #include <ctype.h>
+  #include <sys/stat.h>
 
-#ifdef _WIN32
-  // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
-  #include <windows.h>
-  #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    #define ARCUS_INITED_WIN_TERM_PROC
-    #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+  #ifdef __unix__
+    #include <unistd.h>
   #endif
 
-  void setupConsole(void);
-  void restoreConsole(void);
-  
-  /* Source-End */
+  #ifdef _WIN32
 
-  int32_t setenv(const char* name, const char* value, int32_t overwrite);
-  int32_t unsetenv(const char* name);
-#endif
+    // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
+    #include <windows.h>
+    #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+      #define ARCUS_INITED_WIN_TERM_PROC
+      #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+    #endif
+    /* Source-End */
 
-#define KNRM  "\x1B[0m"
-#define KRED  "\x1B[31m"
-#define KGRN  "\x1B[32m"
-#define KYEL  "\x1B[33m"
-#define KBLU  "\x1B[34m"
-#define KMAG  "\x1B[35m"
-#define KCYN  "\x1B[36m"
-#define KWHT  "\x1B[37m"
+  #endif
 
-#define ARCUS_VER "v0.2.9"
-#define LOLCAT_SUPPORT false
+#pragma endregion INCLUDES
 
-// Source: https://manytools.org/hacker-tools/convert-images-to-ascii-art/go/
-#define SIGMA_SYMBOL_ASCII \
-"                                             \n" \
-"  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@    \n" \
-"    @@@@@@@@@                       @@@@@@   \n" \
-"      @@@@@@@@@                        @@@   \n" \
-"        @@@@@@@@@                       @@   \n" \
-"          @@@@@@@@@                      @   \n" \
-"            @@@@@@@@@                        \n" \
-"              @@@@@@@@@                      \n" \
-"                @@@@@@@@@                    \n" \
-"                  @@@@@@@@@                  \n" \
-"                    @@@@@@@@@                \n" \
-"                      @@@@@                  \n" \
-"                     @@@@                    \n" \
-"                   @@@@                      \n" \
-"                 @@@@                        \n" \
-"               @@@@                          \n" \
-"             @@@@                          @@\n" \
-"           @@@@                           @@ \n" \
-"        @@@@@                           @@@@ \n" \
-"      @@@@@                         @@@@@@@@ \n" \
-"    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  \n" \
-"  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  \n" \
-"                                             \n"
+#pragma region GLOBAL DEFINITIONS
 
-static const char* env_args[][2] = {
-  {
-    "ARCUS_SU_PACMAN",
-    "sudo pacman -S"
-  },
-  {
-    "ARCUS_DEFAULT_PACMAN_ARGS",
-    "--needed --noconfirm"
-  },
-  {
-    "ARCUS_YAY",
-    "yay -S"
-  },
-  {
-    "ARCUS_DEFAULT_YAY_ARGS",
-    "--needed --noconfirm"
-  },
+  #define KNRM  "\x1B[0m"
+  #define KRED  "\x1B[31m"
+  #define KGRN  "\x1B[32m"
+  #define KYEL  "\x1B[33m"
+  #define KBLU  "\x1B[34m"
+  #define KMAG  "\x1B[35m"
+  #define KCYN  "\x1B[36m"
+  #define KWHT  "\x1B[37m"
+
+  #define RET_BASE_COMMAND 47395
+  #define RET_SUB_COMMAND 47396
+
+  #define ARCUS_VER "v1.1.2"
+  #define LOLCAT_SUPPORT false
+
+  // Source: https://manytools.org/hacker-tools/convert-images-to-ascii-art/go/
+  #define SIGMA_SYMBOL_ASCII \
+  "                                             \n" \
+  "  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@    \n" \
+  "    @@@@@@@@@                       @@@@@@   \n" \
+  "      @@@@@@@@@                        @@@   \n" \
+  "        @@@@@@@@@                       @@   \n" \
+  "          @@@@@@@@@                      @   \n" \
+  "            @@@@@@@@@                        \n" \
+  "              @@@@@@@@@                      \n" \
+  "                @@@@@@@@@                    \n" \
+  "                  @@@@@@@@@                  \n" \
+  "                    @@@@@@@@@                \n" \
+  "                      @@@@@                  \n" \
+  "                     @@@@                    \n" \
+  "                   @@@@                      \n" \
+  "                 @@@@                        \n" \
+  "               @@@@                          \n" \
+  "             @@@@                          @@\n" \
+  "           @@@@                           @@ \n" \
+  "        @@@@@                           @@@@ \n" \
+  "      @@@@@                         @@@@@@@@ \n" \
+  "    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  \n" \
+  "  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  \n" \
+  "                                             \n"
+
+static const char* commands[] = {
+  "list",
+  "install",
+  "-h",
+  "--help",
+  "-V",
+  "--version",
+  "--ignore"
 };
-static const size_t n_env_args = sizeof(env_args) / sizeof(env_args[0]);
+static const int32_t n_commands = sizeof(commands) / sizeof(commands[0]);
 
-static const char* packages[][2] = {
-  {
-    "upgrade-pacman",
-    "${ARCUS_SU_PACMAN}yu ${ARCUS_DEFAULT_PACMAN_ARGS}"
-  },
-  {
-    "color-parallel-pacman",
-    "sudo sed -i \"s/#Color/Color/g\" /etc/pacman.conf;"
-    "sudo sed -i \"s/#ParallelDownloads/ParallelDownloads/g\" /etc/pacman.conf"
-  },
-  {
-    "reflector", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};"
-    "sudo cp -i /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak;"
-    "sudo reflector --verbose --latest 10 --protocol https --sort rate --save /etc/pacman.d/mirrorlist"
-  },
-  {
-    "gnome",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} gnome-tweaks"
-  },
-  {
-    "enable_gdm",
-    "sudo systemctl enable --now gdm"
-  },
-  {
-    "valgrind",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "base-devel",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "git",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "yay", 
-    "git clone https://aur.archlinux.org/yay.git;"
-    "cd yay;"
-    "makepkg -si --noconfirm;"
-    "cd ..;"
-    "rm -rf yay"
-  },
-  {
-    "python",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} python-pip python-pipx"
-  },
-  {
-    "clang", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "go", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "gnome-browser-connector", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "openrazer-daemon", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};"
-    "sudo gpasswd -a $USER plugdev"
-  },
-  {
-    "kate",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "mingw-w64",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "mingw-w64-wclang-git",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES} mingw-w64-headers"
-  },
-  {
-    "virtualbox",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} linux-lts-headers;"
-    "sudo modprobe vboxdrv;"
-    "wget -c https://download.virtualbox.org/virtualbox/7.0.12/VBoxGuestAdditions_7.0.12.iso -O ~/Downloads"
-  },
-  {
-    "flatpak", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};"
-    "flatpak update -y"
-  },
-  {
-    "linux",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "linux-lts",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "linux-headers",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "linux-firmware",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "perf", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "intel-ucode", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "otf-comicshanns-nerd",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "noto-fonts",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "p7zip", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "unrar", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "unzip", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "tar", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "rsync", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "neofetch", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "lolcat", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "cmatrix", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "htop", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "exfat-utils", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "exfat-utils", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "fuse-exfat", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "ntfs-3g", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "flac", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "jasper", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "aria2", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "curl", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "wget", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "primary-wallpaper",
-    "sudo wget -c https://w.wallhaven.cc/full/p8/wallhaven-p8dqde.jpg -O /usr/share/backgrounds/primary_wallpaper.jpg"
-  },
-  {
-    "dconf", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "firefox", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "libreoffice-fresh",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "vlc",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "gimp",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "krita",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "nautilus",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "vim",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "gparted",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "wine", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "winetricks", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "wine-mono", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "wine-gecko", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "jdk-openjdk", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "papirus-icon-theme", 
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "nvidia-open",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "catppuccin-gtk-theme-mocha",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES};" 
-    "ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/assets\" \"${HOME}/.config/gtk-4.0/assets\";" 
-    "ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/gtk.css\" \"${HOME}/.config/gtk-4.0/gtk.css\";"
-    "ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/gtk-dark.css\" \"${HOME}/.config/gtk-4.0/gtk-dark.css\""
-  },
-  {
-    "catppuccin-cursors-mocha",
-    "git clone https://github.com/catppuccin/papirus-folders.git catppuccin-papirus-folders;"
-    "sudo cp -r catppuccin-papirus-folders/src/* /usr/share/icons/Papirus;"
-    "catppuccin-papirus-folders/papirus-folders -C cat-mocha-mauve --theme Papirus-Dark;"
-    "rm -rf catppuccin-papirus-folders"
-  },
-  {
-    "catppuccin-grub-mocha",
-    "git clone https://github.com/catppuccin/grub.git catppuccin-grub;"
-    "sudo cp -r catppuccin-grub/src/* /boot/EFI/BOOT/;"
-    "sudo sed -i 's;.*GRUB_THEME=.*;GRUB_THEME=\"/boot/EFI/BOOT/catppuccin-mocha-grub-theme/theme.txt\";g' /etc/default/grub;"
-    "sudo grub-mkconfig -o /boot/grub/grub.cfg;"
-    "rm -rf catppuccin-grub"
-  },
-  {
-    "capslockfix",
-    "sudo bash -c \"curl https://raw.githubusercontent.com/hexvalid/Linux-CapsLock-Delay-Fixer/master/bootstrap.sh > /usr/local/bin/capslockfix.sh\";"
-    "sudo chmod +x /usr/local/bin/capslockfix.sh;"
-    "mkdir -p ~/.config/autostart;"
-    "echo -e \"[Desktop Entry]\nExec=/usr/local/bin/capslockfix.sh\nIcon=dialog-scripts\nName=capslockfix.sh\nType=Application\nX-KDE-AutostartScript=true\" > ~/.config/autostart/capslockfix.sh.desktop;"
-    "sh /usr/local/bin/capslockfix.sh"
-  },
-  {
-    "gnome-terminal-transparency",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "gdm-settings",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "gnome-extensions-cli",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "install-useful-gnome-extensions",
-    "gext install appindicatorsupport@rgcjonas.gmail.com;"
-    "gext install arcmenu@arcmenu.com blur-my-shell@aunetx compiz-windows-effect@hermes83.github.com dash-to-dock@micxgx.gmail.com unblank@sun.wxg@gmail.com Vitals@CoreCoding.com;"
-    "gext enable arcmenu@arcmenu.com blur-my-shell@aunetx compiz-windows-effect@hermes83.github.com dash-to-dock@micxgx.gmail.com unblank@sun.wxg@gmail.com Vitals@CoreCoding.com"
-  },
-  {
-    "visual-studio-code-bin",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "rclone",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} rclone;"
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} rclone-browser"
-  },
-  {
-    "vencord-desktop",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "flathub",
-    "flatpak install flathub -y"
-  },
-  {
-    "vinegar",
-    "flatpak install org.vinegarhq.Vinegar -y"
-  },
-  {
-    "kdenlive",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "steam",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "heroic-games-launcher",
-    "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
-  },
-  {
-    "zsh",
-    "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} powerline-fonts;"
-    "sudo sed -i 's/ZSH_THEME=.*/ZSH_THEME=\"agnoster\"/g' ${HOME}/.zshrc;"
-    "zsh -c \"source ${HOME}/.zshrc\";"
-    "! test -d $ZSH && sh -c \"$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh); exit\"; exit 0"
-  },
-  {
-    "update-all-packages",
-    "${ARCUS_SU_PACMAN}yu ${ARCUS_DEFAULT_PACMAN_ARGS};"
-    "${ARCUS_YAY}yu ${ARCUS_DEFAULT_YAY_ARGS};"
-    "flatpak update -y"
-  }
-};
-static const size_t n_packages = sizeof(packages) / sizeof(packages[0]);
+static char*** packages = NULL;
+static int32_t n_packages = 0;
+static char*** env_args = NULL;
+static int32_t n_env_args = 0;
 
-// Checks whether lolcat is found in /usr/bin
-bool
-has_lolcat(void);
+#pragma endregion GLOBAL DEFINITIONS
 
-/**
- * @author Sigma
- * @param size_out > Writes size of line (including null-terminator) if non-NULL;
- * @param remove_delim > Whether you want to include the delimiter in the line returned;
- * @param delimiter > Specify a delimiter (character to read up to);
- * @param fstream > Stream to read (e.g stdin, stdout);
-*/
-char*
-arcus_getline(
-  size_t* size_out,
-  const bool remove_delim,
-  const char delimiter,
-  FILE* fstream
-);
+#pragma region FUNCTION DECLARATIONS
 
-// Creates an environment variable for the current session
-bool
-set_env(
-  const char* name,
-  const char* value
-);
+  /**
+   * @author https://github.com/SigmaEG/Arcus/Arcus
+   * @brief Checks whether a path exists (File/Directory)
+   * 
+   * @param path > Path to `stat`
+   * 
+   * @return `bool` - > Whether the path exists or not
+  */
+  bool
+  pathexists(const char* path);
 
-// Initializes environment variables for Package Installation
-void
-init_env_args(const bool remove);
+  #pragma region OS-SPECIFIC FUNCTION DECLARATIONS
 
-// Checks whether a package has been specified by the {--ignore ...} switch
-bool
-is_ignored(
-  const char* package,
-  const char** ignore,
-  const size_t n_ignore
-);
+    #ifdef __unix__
 
-// Lists packages to be installed, tagged with [IGNORED] if specified by {--ignore ...} switch
-void
-list_packages(
-  const char** ignore,
-  const size_t n_ignore
-);
+      /**
+       * @author https://github.com/SigmaEG/Arcus/Arcus
+       * @brief Checks whether a user has neofetch installed (Linux only?)
+       * 
+       * @return `bool` > Whether neofetch exists or not
+      */
+      bool
+      has_neofetch(void);
 
-// Installs packages that aren't marked with by the {--ignore ...} switch
-void
-install_packages(
-  const char** ignore,
-  const size_t n_ignore
-);
+      /**
+       * @author https://github.com/SigmaEG/Arcus/Arcus
+       * @brief Checks whether a user has lolcat installed (Linux only?)
+       * 
+       * @return `bool` > Whether the lolcat exists or not
+      */
+      bool
+      has_lolcat(void);
 
-// Compiles an ignore list from argv
-char**
-gen_ignore_list(
-  char** argv,
-  const size_t start_idx,
-  const size_t end_idx
-);
+    #endif
 
-// Displays the Arcus Help Information
-void
-display_help(void);
+    #ifdef _WIN32
 
-// Displays Arcus Version Information
-void
-display_ver(void);
+      // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
+      void enable_ansi(void);
+      void disable_ansi(void);
+
+      int32_t setenv(const char* name, const char* value, int32_t overwrite);
+      int32_t unsetenv(const char* name);
+      /* Source-End */
+
+    #endif
+
+  #pragma endregion OS-SPECIFIC FUNCTION DECLARATIONS
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Reads a line from a `FILE*` stream (stdin, stdout, etc)
+   * 
+   * @param size_out > Writes size of line (including null-terminator) if non-NULL
+   * @param remove_delim > Whether you want to include the delimiter in the line returned
+   * @param delimiter > Specify a delimiter (character to read up to)
+   * @param fstream > Stream to read (e.g stdin, stdout)
+   * 
+   * @return `char*` - > A String to the Line Parsed from `FILE* fstream`
+  */
+  char*
+  arcus_getline(
+    int32_t* size_out,
+    const bool remove_delim,
+    const char delimiter,
+    FILE* fstream
+  );
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Creates an Environment Variable for the Current Session Only
+   * 
+   * @param name > Name of the Environment Variable
+   * @param value > Value of the Environment Variable
+   * 
+   * @return `bool` - > Whether the Environment Variable was successfully set
+  */
+  bool
+  set_env(
+    const char* name,
+    const char* value
+  );
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Initializes environment variables for Package Installation
+   * 
+   * @param remove > Whether the environment args should be removed or not
+   * 
+   * @return `void`
+  */
+  void
+  init_env_args(const bool remove);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Checks whether a package has been specified by the {--ignore ...} switch
+   * 
+   * @param package > Name of the Package to query
+   * @param ignore > The ignore list to query with package
+   * @param n_ignore > Number of ignored packages (size of `ignore`)
+   * 
+   * @return `bool` - > Whether the Package has been flagged as `[IGNORED]`
+  */
+  bool
+  is_ignored(
+    const char* package,
+    const char** ignore,
+    const int32_t n_ignore
+  );
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Lists packages to be installed, tagged with [IGNORED] if specified by {--ignore ...} switch
+   * 
+   * @param ignore > The ignore list to query
+   * @param n_ignore > Number of ignored packages (size of `ignore`)
+   * 
+   * @return `void`
+  */
+  void
+  list_packages(
+    const char** ignore,
+    const int32_t n_ignore
+  );
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Installs packages that aren't marked with by the {--ignore ...} switch.
+   * 
+   * @param ignore > The ignore list to query
+   * @param n_ignore > Number of ignored packages (size of `ignore`)
+   * 
+   * @return `void`
+  */
+  void
+  install_packages(
+    const char** ignore,
+    const int32_t n_ignore
+  );
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Displays Arcus Help Information.
+   * 
+   * @return `void`
+  */
+  void
+  display_help(void);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Displays Arcus Version Information.
+   * 
+   * @return `void`
+  */
+  void
+  display_ver(void);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Parses the Package database from an external file into a usable 2D C-Array.
+   * 
+   * @param size_out > If not NULL, sets the pointer to the amount of elements in `return`
+   * 
+   * @return `char**` - > Returns a 2D C-Style String Array containing the parsed Packages.
+  */
+  char***
+  parse_pkgs(int32_t* size_out);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Parses the Environment Variable database from an external file into a usable 2D C-Array.
+   * 
+   * @param size_out > If not NULL, sets the pointer to the amount of elements in `return`
+   * 
+   * @return `char**` - > Returns a 2D C-Style String Array containing the parsed Environment Variables.
+  */
+  char***
+  parse_envs(int32_t* size_out);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Determines whether a command is valid and is of two categories, a BASE or SUB command.
+   * 
+   * @param cmd_name > Command to parse
+   * 
+   * @return `int32_t` - > Returns -1 such that the command passed is not a valid command in `static const char* commands[]{...}` else see `RET_BASE_COMMAND` and `RET_SUB_COMMAND`
+  */
+  int32_t
+  parse_command(const char* cmd_name);
+
+  /**
+   * @author https://github.com/SigmaEG/Arcus
+   * @brief Parses an argument (command) and its parameters from the argv list.
+   * 
+   * @param argv > Passed from `int32_t main(..., const char** argv)`
+   * @param n_max_argv > Passed from `int32_t main(int32_t argc, ...)`
+   * @param arg_name > Name of the Command to Parse
+   * @param n_expected_params > Amount of Parameters to Expect from Command (use -1 to read until end or next command)
+   * @param n_params_out > Pointer to an external `int32_t` that stores the size of the list on success.
+   * 
+   * @return `const char**` - > Returns a list `const char**` of parameters on success or NULL
+   * @note ON freeing the returned list, DO NOT free its children as they are constant pointers to argv variables.
+  */
+  const char**
+  parse_arguments(
+    const char** argv,
+    const int32_t n_max_argv,
+    const char* arg_name,
+    const int32_t n_expected_params,
+    int32_t* n_params_out
+  );
+
+#pragma endregion FUNCTION DECLARATIONS

--- a/arcus.h
+++ b/arcus.h
@@ -1,11 +1,12 @@
 /**
  * @name Arcus
  * @author https://github.com/SigmaEG/Arcus
- * @note Last Updated: 13th January, 2024
+ * @note Last Updated: 14th January, 2024
  * @note Script Manager
  */
 
 #pragma region INCLUDES
+  #define _POSIX_C_SOURCE 200112L
 
   #include <stdlib.h>
   #include <stdio.h>
@@ -15,11 +16,11 @@
   #include <ctype.h>
   #include <sys/stat.h>
 
-  #ifdef __unix__
+  #if defined(__unix__) || defined(__linux__)
     #include <unistd.h>
   #endif
 
-  #ifdef _WIN32
+  #if defined(_WIN32)
 
     // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
     #include <windows.h>
@@ -109,7 +110,7 @@ static int32_t n_env_args = 0;
 
   #pragma region OS-SPECIFIC FUNCTION DECLARATIONS
 
-    #ifdef __unix__
+    #if defined(__unix__) || defined(__linux__)
 
       /**
        * @author https://github.com/SigmaEG/Arcus/Arcus
@@ -131,7 +132,7 @@ static int32_t n_env_args = 0;
 
     #endif
 
-    #ifdef _WIN32
+    #if defined(_WIN32)
 
       // Source: https://solarianprogrammer.com/2019/04/08/c-programming-ansi-escape-codes-windows-macos-linux-terminals/
       void enable_ansi(void);

--- a/arcus_config/arcus.envs
+++ b/arcus_config/arcus.envs
@@ -1,0 +1,16 @@
+{
+  "ARCUS_SU_PACMAN",
+  "sudo pacman -S"
+},
+{
+  "ARCUS_DEFAULT_PACMAN_ARGS",
+  "--needed --noconfirm"
+},
+{
+  "ARCUS_YAY",
+  "yay -S"
+},
+{
+  "ARCUS_DEFAULT_YAY_ARGS",
+  "--needed --noconfirm"
+}

--- a/arcus_config/arcus.pkgs
+++ b/arcus_config/arcus.pkgs
@@ -1,0 +1,320 @@
+{
+  "upgrade-pacman",
+  "${ARCUS_SU_PACMAN}yu ${ARCUS_DEFAULT_PACMAN_ARGS}"
+},
+{
+  "color-parallel-pacman",
+  "sudo sed -i \"s/#Color/Color/g\" /etc/pacman.conf;sudo sed -i \"s/#ParallelDownloads/ParallelDownloads/g\" /etc/pacman.conf"
+},
+{
+  "reflector",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};sudo cp -i /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak;sudo reflector --verbose --latest 10 --protocol https --sort rate --save /etc/pacman.d/mirrorlist"
+},
+{
+  "gnome",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} gnome-tweaks"
+},
+{
+  "enable_gdm",
+  "sudo systemctl enable --now gdm"
+},
+{
+  "valgrind",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "base-devel",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "git",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "yay",
+  "git clone https://aur.archlinux.org/yay.git;cd yay;makepkg -si --noconfirm;cd ..;rm -rf yay"
+},
+{
+  "python",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} python-pip python-pipx"
+},
+{
+  "clang", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "go", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "gnome-browser-connector", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "openrazer-daemon", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};sudo gpasswd -a $USER plugdev"
+},
+{
+  "kate",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "mingw-w64",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "mingw-w64-wclang-git",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES} mingw-w64-headers"
+},
+{
+  "virtualbox",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} linux-lts-headers;sudo modprobe vboxdrv;wget -c https://download.virtualbox.org/virtualbox/7.0.12/VBoxGuestAdditions_7.0.12.iso -O ~/Downloads"
+},
+{
+  "flatpak", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES};flatpak update -y"
+},
+{
+  "linux",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "linux-lts",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "linux-headers",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "linux-firmware",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "perf", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "intel-ucode", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "otf-comicshanns-nerd",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "noto-fonts",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "p7zip", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "unrar", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "unzip", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "tar", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "rsync", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "neofetch", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "lolcat", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "cmatrix", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "htop", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "exfat-utils", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "exfat-utils", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "fuse-exfat", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "ntfs-3g", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "flac", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "jasper", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "aria2", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "curl", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "wget", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "primary-wallpaper",
+  "sudo wget -c https://w.wallhaven.cc/full/p8/wallhaven-p8dqde.jpg -O /usr/share/backgrounds/primary_wallpaper.jpg"
+},
+{
+  "dconf", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "firefox", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "libreoffice-fresh",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "vlc",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "gimp",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "krita",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "nautilus",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "vim",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "gparted",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "wine", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "winetricks", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "wine-mono", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "wine-gecko", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "jdk-openjdk", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "papirus-icon-theme", 
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "nvidia-open-dkms",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "catppuccin-gtk-theme-mocha",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES};ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/assets\" \"${HOME}/.config/gtk-4.0/assets\";ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/gtk.css\" \"${HOME}/.config/gtk-4.0/gtk.css\";ln -sf \"/usr/share/themes/Catppuccin-Mocha-Standard-Mauve-Dark/gtk-4.0/gtk-dark.css\" \"${HOME}/.config/gtk-4.0/gtk-dark.css\""
+},
+{
+  "catppuccin-cursors-mocha",
+  "git clone https://github.com/catppuccin/papirus-folders.git catppuccin-papirus-folders;sudo cp -r catppuccin-papirus-folders/src/* /usr/share/icons/Papirus;catppuccin-papirus-folders/papirus-folders -C cat-mocha-mauve --theme Papirus-Dark;rm -rf catppuccin-papirus-folders"
+},
+{
+  "catppuccin-grub-mocha",
+  "git clone https://github.com/catppuccin/grub.git catppuccin-grub;sudo cp -r catppuccin-grub/src/* /boot/EFI/BOOT/;sudo sed -i 's;.*GRUB_THEME=.*;GRUB_THEME=\"/boot/EFI/BOOT/catppuccin-mocha-grub-theme/theme.txt\";g' /etc/default/grub;sudo grub-mkconfig -o /boot/grub/grub.cfg;rm -rf catppuccin-grub"
+},
+{
+  "capslockfix",
+  "sudo bash -c \"curl https://raw.githubusercontent.com/hexvalid/Linux-CapsLock-Delay-Fixer/master/bootstrap.sh > /usr/local/bin/capslockfix.sh\";sudo chmod +x /usr/local/bin/capslockfix.sh;mkdir -p ~/.config/autostart;echo -e \"[Desktop Entry]\nExec=/usr/local/bin/capslockfix.sh\nIcon=dialog-scripts\nName=capslockfix.sh\nType=Application\nX-KDE-AutostartScript=true\" > ~/.config/autostart/capslockfix.sh.desktop;sh /usr/local/bin/capslockfix.sh"
+},
+{
+  "gnome-terminal-transparency",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "gdm-settings",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "gnome-extensions-cli",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "install-useful-gnome-extensions",
+  "gext install appindicatorsupport@rgcjonas.gmail.com;gext install arcmenu@arcmenu.com blur-my-shell@aunetx compiz-windows-effect@hermes83.github.com dash-to-dock@micxgx.gmail.com unblank@sun.wxg@gmail.com Vitals@CoreCoding.com;gext enable arcmenu@arcmenu.com blur-my-shell@aunetx compiz-windows-effect@hermes83.github.com dash-to-dock@micxgx.gmail.com unblank@sun.wxg@gmail.com Vitals@CoreCoding.com"
+},
+{
+  "visual-studio-code-bin",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "rclone",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} rclone;${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} rclone-browser"
+},
+{
+  "vencord-desktop",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "flathub",
+  "flatpak install flathub -y"
+},
+{
+  "vinegar",
+  "flatpak install org.vinegarhq.Vinegar -y"
+},
+{
+  "kdenlive",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "steam",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "heroic-games-launcher",
+  "${ARCUS_YAY} ${ARCUS_DEFAULT_YAY_ARGS} ${ARCUS_PACKAGES}"
+},
+{
+  "zsh",
+  "${ARCUS_SU_PACMAN} ${ARCUS_DEFAULT_PACMAN_ARGS} ${ARCUS_PACKAGES} powerline-fonts;sudo sed -i 's/ZSH_THEME=.*/ZSH_THEME=\"agnoster\"/g' ${HOME}/.zshrc;zsh -c \"source ${HOME}/.zshrc\";! test -d $ZSH && sh -c \"$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh); exit\"; exit 0"
+},
+{
+  "update-all-packages",
+  "${ARCUS_SU_PACMAN}yu ${ARCUS_DEFAULT_PACMAN_ARGS};${ARCUS_YAY}yu ${ARCUS_DEFAULT_YAY_ARGS};flatpak update -y"
+}

--- a/build-lib.sh
+++ b/build-lib.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 clang \
   -c \
   -Wall \
@@ -12,3 +14,5 @@ ar \
   libarcus.o
 
 rm -f libarcus.o
+
+echo "< SUCCESSFULLY COMPILED arcus.c INTO libarcus.a >"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
+#!/usr/bin/bash
+
 clang \
   -Wall \
   -Wextra \
   -pedantic \
   -o arcus-linux \
   arcus.c
+
+echo -e "clang \\ \n  -Wall \\ \n  -Wextra \\ \n  -pedantic \\ \n  -o arcus-linux \\ \n  arcus.c \n< SUCCESSFULLY COMPILED >"


### PR DESCRIPTION
> Bumped to `v1.1.2` from `v0.2.9`
> Implemented `Arcus` `*.pkgs` and `*.envs` files into `arcus_config`, strict-syntaxing
> Now reads from such `Arcus` files instead of relying on internal 2D C-Style String Arrays.
> Rewrote `--ignore` argument parser